### PR TITLE
Updating for Scrapy 1.0, fix autologin.py bugs

### DIFF
--- a/crawler/logincrawl/pipelines.py
+++ b/crawler/logincrawl/pipelines.py
@@ -9,18 +9,18 @@ import traceback
 from loginform.loginform import LoginFormFinder
 from crawler.logincrawl.items import AuthInfoItem
 import pickledb
-from scrapy import log
+import logging
 
 class LoginCrawlPipeline(object):
 
     def process_item(self, item, spider):
         #add url to list of keys/urls
-        log.msg("Processing an AuthInfoItem", level = log.INFO)
+        logging.info("Processing an AuthInfoItem")
 
         self.db_location = spider.db_name
         self.db = pickledb.load(self.db_location, False)
         self.db.lcreate("auth_urls")
-        log.msg("Using db at location %s" % self.db_location, level = log.INFO)
+        logging.info("Using db at location %s" % self.db_location)
         
         if isinstance(item, AuthInfoItem):
             if item["response_url"] not in self.db.lgetall("auth_urls"):

--- a/crawler/logincrawl/spiders/login_finder.py
+++ b/crawler/logincrawl/spiders/login_finder.py
@@ -3,8 +3,8 @@ from scrapy.utils.response import open_in_browser
 from urlparse import urlparse
 from loginform.loginform import LoginFormFinder
 from scrapy.http import FormRequest
-from scrapy.contrib.linkextractors import LinkExtractor
-from scrapy.contrib.spiders import CrawlSpider, Rule
+from scrapy.linkextractors import LinkExtractor
+from scrapy.spiders import CrawlSpider, Rule
 from crawler.logincrawl.items import AuthInfoItem
 from crawler.logincrawl.items import LoginCrawlItem
 import traceback
@@ -35,7 +35,6 @@ class LoginFinderSpider(CrawlSpider):
         self.db_name = db_name
 
     def parse_item(self, response):
-        
         item = LoginCrawlItem()
         item["url"] = response.url
         item["host"] = urlparse(response.url).netloc

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ flask
 pickledb
 python-scrapyd-api
 requests
-scrapy
+scrapy>=1.0
 scrapyd
 sphinx
+service_identity


### PR DESCRIPTION
Fixed - use standard python logging as per http://doc.scrapy.org/en/latest/topics/logging.html (various)
Fixed - db_name wasn't being passed to the AutoLogin class (autologin.py)
Updated - Exception handling for reactor.stop() (autologin.py)
Fixed - auth_headers and redirect_to restored as return statement for get_auth_headers_and_redirect_to()  (autologin.py)
Updated - scrapy.spiders instead of scrapy.contrib.spiders  (various)