### PR TITLE
Formasaurus is an option. 

### DIFF
--- a/crawler/logincrawl/pipelines.py
+++ b/crawler/logincrawl/pipelines.py
@@ -7,9 +7,10 @@
 import json
 import traceback
 from loginform.loginform import LoginFormFinder
-from crawler.logincrawl.items import AuthInfoItem
+from crawler.logincrawl.items import AuthInfoItem, LoginCrawlItem
 import pickledb
 import logging
+from scrapy.exceptions import DropItem
 
 class LoginCrawlPipeline(object):
 
@@ -27,3 +28,5 @@ class LoginCrawlPipeline(object):
                 self.db.ladd("auth_urls", item["response_url"])
                 self.db.set(item["response_url"], dict(item))
                 self.db.dump()
+        elif isinstance(item, LoginCrawlItem):
+            raise DropItem("LoginCrawlItem")

--- a/crawler/logincrawl/settings.py
+++ b/crawler/logincrawl/settings.py
@@ -21,3 +21,5 @@ USER_AGENT = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:33.0) Gecko/20100101 Fi
 ITEM_PIPELINES = {
     'crawler.logincrawl.pipelines.LoginCrawlPipeline': 800
 }
+CONCURRENT_REQUESTS_PER_DOMAIN = 1
+DOWNLOAD_DELAY = 1 

--- a/scrapydutils.py
+++ b/scrapydutils.py
@@ -4,7 +4,7 @@ import time
 
 class ScrapydLoginFinderJob(object):
 
-    def __init__(self, seed_url, username, password, db_name, scrapyd_host="localhost", scrapyd_port="6800", project="default", spider="login_finder"):
+    def __init__(self, seed_url, username, password, db_name, use_formasaurus=True, scrapyd_host="localhost", scrapyd_port="6800", project="default", spider="login_finder"):
 
         scrapy_url = "http://" + scrapyd_host + ":" + str(scrapyd_port)
         self.scrapi = ScrapydAPI(scrapy_url)
@@ -14,10 +14,12 @@ class ScrapydLoginFinderJob(object):
         self.username = username
         self.password = password
         self.db_name = db_name
+        self.use_formasaurus = use_formasaurus
+        print 'LoginFinderJob use formasaurus? %s' % self.use_formasaurus
 
     def schedule(self):
 
-        self.job_id = self.scrapi.schedule(self.project, self.spider, seed_url = self.seed_url, username = self.username, password = self.password, db_name = self.db_name)
+        self.job_id = self.scrapi.schedule(self.project, self.spider, seed_url = self.seed_url, username = self.username, password = self.password, db_name = self.db_name, use_formasaurus = self.use_formasaurus)
 
         return self.job_id
 

--- a/service.py
+++ b/service.py
@@ -16,6 +16,7 @@ def autologin():
     seed_url = request.args.get("seedurl")
     username = request.args.get("username")
     password = request.args.get("password")
+    use_formasaurus = request.args.get("formasaurus")
     open_in_browser = request.args.get("openinbrowser")
 
     hash = hashlib.sha1()
@@ -25,15 +26,21 @@ def autologin():
     if not seed_url or not username or not password:
         raise Exception("Missing a needed parameter")
 
-    slfj = ScrapydLoginFinderJob(seed_url, username, password, db_name)
+    if use_formasaurus == "0":
+        use_formasaurus = False
+    else:
+        use_formasaurus = True 
+
+    slfj = ScrapydLoginFinderJob(seed_url, username, password, db_name, use_formasaurus=use_formasaurus)
     slfj.schedule()
     slfj.block_until_done()
     
     al = AutoLogin(db_name)
     auth_info = al.get_auth_info()
+    print 'Waaaaaaaaa? %s'  % open_in_browser
 
-    if open_in_browser:
-
+    if open_in_browser == "1":
+        print 'Opening browser'
         tmp_response_file = "/tmp/openinbrowser.html" 
         f = open(tmp_response_file, "w")
         f.write(auth_info["response_body"].encode("utf-8"))


### PR DESCRIPTION
Formasaurus is used by default, unless formasaurus=0 is part of the request to scrapyd. 
Set some scrapy settings defaults for the loginspider to ensure firewalls aren't triggered: 1 concurrent request per domain, and download_delay of 1 second. This should become a option parameter later on.
Couple bug fixes.