### PR TITLE
Splash support

### DIFF
--- a/autologin/middleware.py
+++ b/autologin/middleware.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import  
+from __future__ import absolute_import
+
 from scrapy.downloadermiddlewares.cookies import CookiesMiddleware
 from scrapy.http.cookies import CookieJar
 

--- a/autologin/spiders.py
+++ b/autologin/spiders.py
@@ -71,27 +71,30 @@ class DefaultExecuteSplashRequest(SplashRequest):
     for the execute endpoint with support for POST requests and cookies.
     '''
     SPLASH_SCRIPT = '''
-    function last_response_headers(splash)
-        local entries = splash:history()
-        local last_entry = entries[#entries]
-        return last_entry.response.headers
-    end
-
     function main(splash)
         splash:init_cookies(splash.args.cookies)
-        assert(splash:go{
+        local ok, reason = splash:go{
             splash.args.url,
             headers=splash.args.headers,
             http_method=splash.args.http_method,
             body=splash.args.body,
-            })
-        assert(splash:wait(0.5))
-
-        return {
-            headers=last_response_headers(splash),
-            cookies=splash:get_cookies(),
-            html=splash:html(),
         }
+        if ok then
+            assert(splash:wait(0.5))
+        end
+
+        local entries = splash:history()
+        if #entries > 0 then
+            local last_response = entries[#entries].response
+            return {
+                headers=last_response.headers,
+                cookies=splash:get_cookies(),
+                html=splash:html(),
+                http_status=last_response.status,
+            }
+        else
+            assert(false, reason)
+        end
     end
     '''
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ wtforms
 flask-sqlalchemy
 flask-admin
 scrapy==1.1.0rc3
--e git+git@github.com:scrapy-plugins/scrapy-splash.git@fa4f287cf2c2524ac1fa201e061e64e5b47d83bf#egg=scrapyjs
+-e git+git@github.com:lopuhin/scrapy-splash.git@8c08ad60d1668a9160c63c32801a04e49c5671b2#egg=scrapyjs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 six
 lxml
-Flask
-wtforms
-flask-sqlalchemy
-flask-admin
+Flask==0.10.1
+Flask-Admin==1.4.0
+Flask-SQLAlchemy==2.1
+Flask-WTF==0.12
+WTForms==2.1
 scrapy==1.1.0rc3
+formasaurus[with-deps]==0.7.1
 -e git+git@github.com:lopuhin/scrapy-splash.git@8c08ad60d1668a9160c63c32801a04e49c5671b2#egg=scrapyjs

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ Flask-WTF==0.12
 WTForms==2.1
 scrapy==1.1.0rc3
 formasaurus[with-deps]==0.7.1
--e git+git@github.com:lopuhin/scrapy-splash.git@8c08ad60d1668a9160c63c32801a04e49c5671b2#egg=scrapyjs
+-e git+git@github.com:scrapy-plugins/scrapy-splash.git@127e2358203f0cd52518761ea2a891800f0f0ef6#egg=scrapyjs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+six
+lxml
+Flask
+wtforms
+flask-sqlalchemy
+flask-admin
+scrapy==1.1.0rc3
+-e git+git@github.com:scrapy-plugins/scrapy-splash.git@fa4f287cf2c2524ac1fa201e061e64e5b47d83bf#egg=scrapyjs

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,6 @@ setup(
     install_requires = [
         'six',
         'lxml',
-        'Flask',
-        'wtforms',
-        'flask-sqlalchemy',
-        'flask-admin',
-        'scrapy==1.1.0rc3',
     ],
     scripts = [
         'bin/autologin-server',


### PR DESCRIPTION
Splash is used for finding login form and logging in if ``splash_url`` is passed as an argument to the http API.

I checked that Tor and phpbb3 now work. The only interesting bit is the splash script, especially errors handling - perhaps there is a better way?

Also, I've moved some requirements to ``requirements.txt`` with the idea that ``setup.py`` contains only libs required to use it as a library (I think this was the original idea in master).