### PR TITLE
Pass extra js on login page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,8 @@ Command Line
 ::
 
     $ autologin
-    usage: autologin [-h] [--splash-url SPLASH_URL] [--show-in-browser]
+    usage: autologin [-h] [--splash-url SPLASH_URL] [--extra-js EXTRA_JS]
+                     [--show-in-browser]
                      username password url
 
 

--- a/README.rst
+++ b/README.rst
@@ -109,11 +109,15 @@ If you have a Scrapy spider (or use Twisted in some other way),
 use the HTTP API, or the non-blocking API (it's not documented,
 see ``http_api.AutologinAPI._login``).
 
-There are two opitonal arguments for ``AutoLogin.auth_cookies_from_url``:
+There are also opitonal arguments for ``AutoLogin.auth_cookies_from_url``:
 
 - ``splash_url`` if set, `Splash <http://splash.readthedocs.org>`_
   will be used to make all requests. Use it if your cawler also uses
   splash and the session is tied to IP and User-Agent, or for Tor sites.
+- ``extra_js`` (experimental)
+  is a string with an extra JS script that should be executed
+  on the login page before making a POST request. For example, it can be used
+  to accept cookie use. It is supported only when ``splash_url`` is also given.
 - ``settings`` is a dictionary with Scrapy settings to override.
   Use it e.g. to set a custom User-Agent with scrapy ``USER_AGENT`` option.
 
@@ -122,6 +126,7 @@ An example of using this options::
     cookies = al.auth_cookies_from_url(
         url, username, password,
         splash_url='http://127.0.0.1:8050',
+        extra_js='document.getElementById("accept-cookies").click();',
         settings={'USER_AGENT': 'Mozilla/2.02 [fr] (WinNT; I)'})
 
 
@@ -169,6 +174,10 @@ The following arguments are supported:
 - ``splash_url`` (optional): if set, `Splash <http://splash.readthedocs.org>`_
   will be used to make all requests. Use it if your cawler also uses
   splash and the session is tied to IP and User-Agent, or for Tor sites.
+- ``extra_js`` (optional, experimental)
+  is a string with an extra JS script that should be executed
+  on the login page before making a POST request. For example, it can be used
+  to accept cookie use. It is supported only when ``splash_url`` is also given.
 - ``settings`` (optional) - a dictionary with Scrapy settings to override.
   Use it e.g. to set a custom User-Agent with scrapy ``USER_AGENT`` option.
 

--- a/autologin/autologin.py
+++ b/autologin/autologin.py
@@ -101,15 +101,26 @@ def main():
     argparser.add_argument('username', help='login username')
     argparser.add_argument('password', help='login password')
     argparser.add_argument('url', help='url for the site you wish to login to')
-    argparser.add_argument('--splash-url')
+    argparser.add_argument(
+        '--splash-url',
+        help='URL of the splash instance (by default splash is not used)')
+    argparser.add_argument(
+        '--extra-js', help='path to extra js script executed on login page')
     argparser.add_argument('--show-in-browser', '-b',
         help='show page in browser after login (default: False)',
         action='store_true')
     args = argparser.parse_args()
     # Try logging into site
     auto_login = AutoLogin()
+    if args.extra_js:
+        with open(args.extra_js, 'rb') as f:
+            extra_js = f.read().decode('utf-8')
+    else:
+        extra_js = None
     login_cookies = auto_login.auth_cookies_from_url(
-        args.url, args.username, args.password, splash_url=args.splash_url)
+        args.url, args.username, args.password,
+        splash_url=args.splash_url,
+        extra_js=extra_js)
     # Print extracted cookies
     pprint.pprint(login_cookies.__dict__)
     # Open browser tab with page using cookies

--- a/autologin/autologin.py
+++ b/autologin/autologin.py
@@ -20,7 +20,7 @@ class AutoLoginException(Exception):
 
 class AutoLogin(object):
     def auth_cookies_from_url(self, url, username, password, splash_url=None,
-                              settings=None):
+                              extra_js=None, settings=None):
         """
         Fetch page, find login form, try to login and return cookies.
         This call is blocking, and we assume that Twisted reactor is not used.
@@ -36,7 +36,8 @@ class AutoLogin(object):
                 splash_url=splash_url, extra_settings=settings)
             items = scrape_items(
                 runner, LoginSpider,
-                url=url, username=username, password=password)
+                url=url, username=username, password=password,
+                extra_js=extra_js)
             d = items.fetch_next
             d.addCallback(lambda result: items.next_item() if result else
                                          {'ok': False, 'error': 'noresult'})

--- a/autologin/directives/login.lua
+++ b/autologin/directives/login.lua
@@ -8,6 +8,12 @@ function main(splash)
     }
     if ok then
         assert(splash:wait(0.5))
+
+        if splash.args.extra_js then
+          assert(splash:runjs(splash.args.extra_js))
+          assert(splash:wait(1.0))
+        end
+
         splash:set_viewport_full()
     end
 

--- a/autologin/spiders.py
+++ b/autologin/spiders.py
@@ -103,6 +103,9 @@ class BaseSpider(scrapy.Spider):
                 splash_request, lua_source,
                 extra_js=self.extra_js)
         else:
+            if self.extra_js:
+                raise ValueError(
+                    '"extra_js" not supported without "splash_url"')
             self.request = scrapy.Request
         for url in self.start_urls:
             yield self.request(url, callback=self.parse)

--- a/autologin/spiders.py
+++ b/autologin/spiders.py
@@ -75,6 +75,9 @@ def splash_request(lua_source, *args, **kwargs):
     kwargs['endpoint'] = 'execute'
     splash_args = kwargs.setdefault('args', {})
     splash_args['lua_source'] = lua_source
+    extra_js = kwargs.pop('extra_js', None)
+    if extra_js:
+        splash_args['extra_js'] = extra_js
     return SplashRequest(*args, **kwargs)
 
 
@@ -85,6 +88,10 @@ class BaseSpider(scrapy.Spider):
     """
     lua_source = 'default.lua'
 
+    def __init__(self, *args, **kwargs):
+        self.extra_js = kwargs.pop('extra_js', None)
+        super(BaseSpider, self).__init__(*args, **kwargs)
+
     def start_requests(self):
         self.using_splash = bool(self.settings.get('SPLASH_URL'))
         if self.using_splash:
@@ -92,7 +99,9 @@ class BaseSpider(scrapy.Spider):
                     os.path.dirname(__file__), 'directives', self.lua_source),
                     'rb') as f:
                 lua_source = f.read().decode('utf-8')
-            self.request = partial(splash_request, lua_source)
+            self.request = partial(
+                splash_request, lua_source,
+                extra_js=self.extra_js)
         else:
             self.request = scrapy.Request
         for url in self.start_urls:


### PR DESCRIPTION
This can be useful to perform additional actions on the login page before making POST request, for example accept cookie use (FB login from EU IPs did not work without it).
We also considered allowing passing splash script instead of JS, but decided to go with something simpler first (also, lua in splash does not support ``load`` by default, and building a script dynamically before sending feels rather hacky).