### PR TITLE
Fix db config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -249,6 +249,19 @@ Start keychain UI with::
 Note that both ``autologin-server`` and ``autologin-http-api``
 are not protected by any authentication.
 
+Keychain UI stores credentials in an sqlite database. It is located near
+the library itself by default, which is not always good, especially if you want
+to persist the data between updates or do not have write permissions
+for that folder. You can configure database location and
+``secret_key`` used by the flask app by creating an ``/etc/autologin.cfg`` or
+``~/.autologin.cfg`` file (should be the same user under which autologin
+services are running). Here is an example config that changes default secret_key
+and specifies a different database path (both items are optional)::
+
+    [autologin]
+    secret_key = 8a0b923820dcc509a6f75849b
+    db = /var/autologin/db.sqlite
+
 
 Contributors
 ------------

--- a/autologin/app.py
+++ b/autologin/app.py
@@ -10,20 +10,51 @@ server_path = os.path.dirname(os.path.realpath(__file__))
 static_dir = os.path.join(server_path, 'static')
 browser_dir = os.path.join(static_dir, 'browser')
 
-# Read config (defaults are in autologin.conf)
-config = configparser.ConfigParser()
-# Read default config
-config.read(os.path.join(server_path, 'autologin.cfg'))
-# Override by user-supplied config
-config.read([
-    os.path.expanduser('~/.autologin.cfg'),
-    '/etc/autologin.cfg',
-    ])
 
-# Initiate flask app
-app = Flask(__name__)
-app.secret_key = config.get('autologin', 'secret_key')
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///{}'.format(os.path.abspath(
-    os.path.join(config.get('autologin', 'db_folder'), 'db.sqlite')))
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+def init_app():
+    # Read config (defaults are in autologin.conf)
+    config = configparser.ConfigParser()
+    # Read default config
+    default_config = os.path.join(server_path, 'autologin.cfg')
+    config.read(default_config)
+    # Override by user-supplied config
+    user_configs = [
+        os.path.expanduser('~/.autologin.cfg'),
+        '/etc/autologin.cfg',
+        ]
+    config.read(user_configs)
+    used_config = default_config
+    for path in user_configs:
+        if os.path.exists(path):
+            used_config = path
+            break
+
+    # Initiate flask app
+    app = Flask(__name__)
+    app.secret_key = config.get('autologin', 'secret_key')
+    try:
+        db_path = config.get('autologin', 'db')
+    except configparser.NoOptionError:
+        db_path = os.path.join(os.path.dirname(__file__), 'db.sqlite')
+    else:
+        if not os.path.isabs(db_path):
+            raise RuntimeError(
+                'You must specify an absolute path to the database. '
+                'Invalid relative path "{db_path}" in config file {used_config}'
+                .format(db_path=db_path, used_config=used_config))
+    assert os.path.isabs(db_path)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///{}'.format(db_path)
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    return app
+
+
+def init_db():
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.info('Keychain UI database: %s'
+                % app.config['SQLALCHEMY_DATABASE_URI'])
+    db.create_all()
+
+
+app = init_app()
 db = SQLAlchemy(app)

--- a/autologin/autologin.cfg
+++ b/autologin/autologin.cfg
@@ -1,3 +1,2 @@
 [autologin]
 secret_key = b334r9asdfmasdfkasdf90joa
-db_folder = autologin

--- a/autologin/autologin.docker.cfg
+++ b/autologin/autologin.docker.cfg
@@ -1,2 +1,2 @@
 [autologin]
-db_folder = /var/autologin
+db = /var/autologin/db.sqlite

--- a/autologin/http_api.py
+++ b/autologin/http_api.py
@@ -8,7 +8,7 @@ from twisted.web.server import Site, NOT_DONE_YET
 from twisted.web.resource import Resource
 from scrapy.utils.log import configure_logging
 
-from .app import app, db
+from .app import app, init_db
 from .login_keychain import KeychainItem
 from .spiders import FormSpider, LoginSpider, crawl_runner, cookie_dicts
 from .scrapyutils import scrape_items
@@ -126,7 +126,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--port', type=int, default=8089)
     args = parser.parse_args()
-    db.create_all()
+
+    init_db()
     logger.info("Autologin HTTP API is started on port %s" % args.port)
     reactor.listenTCP(args.port, Site(root))
     reactor.run()

--- a/autologin/server.py
+++ b/autologin/server.py
@@ -11,7 +11,7 @@ import requests
 
 from .autologin import AutoLogin
 from .forms import LoginForm
-from .app import app, db, server_path
+from .app import app, db, server_path, init_db
 from .login_keychain import KeychainItemAdmin, KeychainItem
 from .autologin import cookie_request, AutoLoginException
 
@@ -124,7 +124,7 @@ def main():
     parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()
 
-    db.create_all()
+    init_db()
     admin = flask_admin.Admin(app, template_mode='bootstrap3')
     admin.add_view(KeychainItemAdmin(KeychainItem, db.session))
 

--- a/autologin/server.py
+++ b/autologin/server.py
@@ -8,6 +8,7 @@ from flask import render_template
 from flask import flash
 import flask_admin
 import requests
+from scrapy.utils.log import configure_logging
 
 from .autologin import AutoLogin
 from .forms import LoginForm
@@ -118,6 +119,7 @@ def index():
 
 def main():
     import argparse
+    configure_logging()
     parser = argparse.ArgumentParser()
     parser.add_argument('--host', default='127.0.0.1')
     parser.add_argument('--port', type=int, default=8088)


### PR DESCRIPTION
Now we specify the absolute path in ``db`` argument, and it lives near the lib by default. I also updated the docs because the user is likely to tweak this setting.

@lukemaxwell this should fix the issue you had with db file location.